### PR TITLE
Spelling fix to prevent error

### DIFF
--- a/test/spec/basecampAssessmentOne.js
+++ b/test/spec/basecampAssessmentOne.js
@@ -56,6 +56,6 @@ describe('sum', function () {
 
 describe('greeter', function () {
 	it('should return the correct response', function () {
-		expect(greeter('Bryan', 28)).toEqual(`Hi! I'm Bryan and I am 28 years old`)
+		expect(greeter('Bryan', 28)).toEqual(`Hi! I am Bryan and I am 28 years old`)
 	})
 })


### PR DESCRIPTION
Jasmine is currently looking for "I'm" while the assignment is asking for "I am". Changing to prevent an unneeded error when index.html is opened. Issue was occurring on problem #10 (resubmitted per request)