### PR TITLE
fixed typo in specrunner

### DIFF
--- a/test/spec/basecampAssessmentOne.js
+++ b/test/spec/basecampAssessmentOne.js
@@ -24,7 +24,7 @@ describe('me', function () {
 
 describe('trueFaveNum', function () {
 	it('should be equal to your faveNum variable', function () {
-		expect(trueFaveNum).toEqual(true);
+		expect(trueFaveNum === faveNum).toEqual(true);
 	})
 })
 


### PR DESCRIPTION
updated the trueFaveNum test case to test if the variable was equal to faveNum, instead of testing to see if it had the value of true.